### PR TITLE
Download > Legacy Releases

### DIFF
--- a/p4-download.md
+++ b/p4-download.md
@@ -1,8 +1,6 @@
 ---
 layout: page
-menu: main
 title: Legacy Releases
-menu_title: Download
 permalink: /Download/
 ---
 

--- a/p4-download.md
+++ b/p4-download.md
@@ -1,13 +1,16 @@
 ---
 layout: page
 menu: main
-title: Download
+title: Legacy Releases
 menu_title: Download
 permalink: /Download/
 ---
 
 [CoovaChilli](/CoovaChilli/)
 ============================
+
+Current releases are now available directly from the [release section of the github repo](https://github.com/coova/coova-chilli/releases/latest).
+The releases listed here are retained for historical purposes.
 
 * [coova-chilli-1.3.0.tar.gz](/coova-chilli/coova-chilli-1.3.0.tar.gz)
 * [coova-chilli-1.2.9.tar.gz](/coova-chilli/coova-chilli-1.2.9.tar.gz)


### PR DESCRIPTION
Retain the download page to not break existing links from blog etc.
Rename page tittle to legacy releases.
Remove the page from the top menu.